### PR TITLE
add edge_diffs count to --summary; fix README output example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,21 +41,21 @@ sbom-diff old.json new.json --quiet --fail-on added-components
 
 ### text output (default)
 ```text
-diff summary
+Diff Summary
 ============
-added:   1
-removed: 0
-changed: 1
+Added:   1
+Removed: 0
+Changed: 1
 
-[+] added
+[+] Added
 ---------
 pkg:npm/left-pad@1.3.0
 
-[~] changed
+[~] Changed
 -----------
 pkg:cargo/serde@1.0.191
-  version: 1.0.190 -> 1.0.191
-  license: ["mit"] -> ["mit", "apache-2.0"]
+  Version: 1.0.190 -> 1.0.191
+  License: {"mit"} -> {"apache-2.0", "mit"}
 ```
 
 ## installation

--- a/crates/sbom-diff/src/main.rs
+++ b/crates/sbom-diff/src/main.rs
@@ -170,9 +170,10 @@ fn check_licenses(sbom: &Sbom, deny: &[String], allow: &[String]) -> bool {
 }
 
 fn render_summary(diff: &sbom_diff::Diff, out: &mut impl io::Write) -> io::Result<()> {
-    writeln!(out, "Added:   {}", diff.added.len())?;
-    writeln!(out, "Removed: {}", diff.removed.len())?;
-    writeln!(out, "Changed: {}", diff.changed.len())?;
+    writeln!(out, "Added:        {}", diff.added.len())?;
+    writeln!(out, "Removed:      {}", diff.removed.len())?;
+    writeln!(out, "Changed:      {}", diff.changed.len())?;
+    writeln!(out, "Edge changes: {}", diff.edge_diffs.len())?;
     Ok(())
 }
 
@@ -377,9 +378,42 @@ mod tests {
         render_summary(&diff, &mut buf).unwrap();
         let out = String::from_utf8(buf).unwrap();
 
-        assert!(out.contains("Added:   2"));
-        assert!(out.contains("Removed: 1"));
-        assert!(out.contains("Changed: 0"));
+        assert!(out.contains("Added:        2"));
+        assert!(out.contains("Removed:      1"));
+        assert!(out.contains("Changed:      0"));
+        assert!(out.contains("Edge changes: 0"));
+    }
+
+    #[test]
+    fn test_render_summary_with_edge_diffs() {
+        use sbom_diff::{Diff, EdgeDiff};
+        use sbom_model::ComponentId;
+        use std::collections::BTreeSet;
+
+        let diff = Diff {
+            added: vec![],
+            removed: vec![],
+            changed: vec![],
+            edge_diffs: vec![
+                EdgeDiff {
+                    parent: ComponentId::new(None, &[("name", "pkg-a")]),
+                    added: BTreeSet::from([ComponentId::new(None, &[("name", "pkg-b")])]),
+                    removed: BTreeSet::new(),
+                },
+                EdgeDiff {
+                    parent: ComponentId::new(None, &[("name", "pkg-c")]),
+                    added: BTreeSet::new(),
+                    removed: BTreeSet::from([ComponentId::new(None, &[("name", "pkg-d")])]),
+                },
+            ],
+            metadata_changed: false,
+        };
+
+        let mut buf = Vec::new();
+        render_summary(&diff, &mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+
+        assert!(out.contains("Edge changes: 2"));
     }
 
     #[test]


### PR DESCRIPTION
## What

Two small fixes to improve consistency between the code and its documentation.

### 1. `--summary` now includes edge changes

`render_summary` previously printed only `Added`, `Removed`, and `Changed` counts, silently omitting dependency-edge changes even when `--fail-on deps` was the whole point of the run. The summary now includes an `Edge changes:` line:

```
Added:        0
Removed:      0
Changed:      0
Edge changes: 3
```

### 2. README text-output example corrected

The README example under "text output (default)" showed lowercase section headers and field names (`diff summary`, `added:`, `[+] added`, `license:`) that don't match what `TextRenderer` actually produces. Updated to match actual output (`Diff Summary`, `Added:`, `[+] Added`, `License:`).

## Tests

- Updated the existing `test_render_summary` assertions to match the new aligned column format.
- Added `test_render_summary_with_edge_diffs` to cover the new line explicitly.
- All existing tests pass.