### PR TITLE
fix: flag unlicensed components when --allow-license is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- flag unlicensed components as violations when `--allow-license` is active
+
 ## [0.1.0] - 2026-04-08
 
 - add CycloneDX XML support (1.3, 1.4, 1.5); new `--format cyclonedx-xml` flag and auto-detection

--- a/crates/sbom-diff/src/main.rs
+++ b/crates/sbom-diff/src/main.rs
@@ -149,6 +149,15 @@ fn main() -> anyhow::Result<()> {
 fn check_licenses(sbom: &Sbom, deny: &[String], allow: &[String]) -> bool {
     let mut violation = false;
     for comp in sbom.components.values() {
+        // A component with no license information cannot satisfy an allow-list.
+        if !allow.is_empty() && comp.licenses.is_empty() {
+            eprintln!(
+                "error: component {} has no license information (--allow-license requires it)",
+                comp.id
+            );
+            violation = true;
+            continue;
+        }
         for license in &comp.licenses {
             if !deny.is_empty() && deny.contains(license) {
                 eprintln!(
@@ -461,6 +470,24 @@ mod tests {
         let sbom = Sbom::default();
         // No components, no violations
         assert!(!check_licenses(&sbom, &[], &[]));
+    }
+
+    #[test]
+    fn test_check_licenses_unlicensed_component_with_allowlist() {
+        let mut sbom = Sbom::default();
+        // Component with no license information
+        let c = Component::new("unlicensed-pkg".into(), Some("1.0".into()));
+        // licenses is empty by default
+        sbom.components.insert(c.id.clone(), c);
+
+        // No allow-list: unlicensed component is not a violation
+        assert!(!check_licenses(&sbom, &[], &[]));
+
+        // With allow-list: unlicensed component cannot satisfy it → violation
+        assert!(check_licenses(&sbom, &[], &["MIT".into()]));
+
+        // With deny-list only: unlicensed component is not a violation (nothing to deny)
+        assert!(!check_licenses(&sbom, &["GPL-3.0-only".into()], &[]));
     }
 
     #[test]


### PR DESCRIPTION
## What

`check_licenses` now flags components that have **no license information** when `--allow-license` is set and exits with code 2 for them.

Previously, a component with an empty `licenses` set silently passed the allow-list check because the inner loop never executed — allowing unlicensed components to slip through compliance gating unnoticed.

## Why

If you're running `sbom-diff --allow-license MIT` to enforce that every component is MIT-licensed, a component with no license declaration should be a violation, not a silent pass. The allow-list is meaningless for compliance purposes if unlicensed components are exempt.

Deny-list (`--deny-license`) is unaffected: there's nothing to deny on an unlicensed component, so that path stays quiet.

## Changes

- `check_licenses`: added an early check per component — if the allow-list is non-empty and `comp.licenses` is empty, emit an error and mark violation
- Added `test_check_licenses_unlicensed_component_with_allowlist` covering the three cases (no lists, allow-list, deny-list-only)

---
_Opened by the cyberwitchery heartbeat agent (Claude). Veit has not reviewed this yet._