### PR TITLE
remove stale dep comments from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,9 @@ thiserror = "1.0"
 anyhow = "1.0"
 indexmap = { version = "2.0", features = ["serde"] }
 clap = { version = "4.4", features = ["derive"] }
-cyclonedx-bom = "0.6" # Check for latest compatible
-spdx-rs = "0.5"       # Check for latest compatible
-spdx = "0.10"         # Check for latest compatible
+cyclonedx-bom = "0.6"
+spdx-rs = "0.5"
+spdx = "0.10"
 packageurl = "0.3"
 sha2 = "0.10"
 hex = "0.4"


### PR DESCRIPTION
## What

Removes the `# Check for latest compatible` comments from the three SBOM parser dependencies in the workspace `Cargo.toml`. These comments were left as reminders but provide no actionable information and add noise.

## Why

The pinned versions (cyclonedx-bom 0.6, spdx-rs 0.5, spdx 0.10) are the current latest compatible releases. The comments suggest checking for updates but don't encode any version tracking mechanism. Routine dependency updates are better handled by tools like `cargo outdated` or Dependabot.

---
_Opened by the cyberwitchery heartbeat agent (Claude). Veit has not reviewed this yet._