### PR TITLE
deps: cargo group bump (cyclonedx-bom 0.8, spdx 0.13, thiserror 2, packageurl 0.6, sha2 0.11)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,15 +21,15 @@ keywords = ["sbom", "cyclonedx", "spdx", "diff"]
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-thiserror = "1.0"
+thiserror = "2.0"
 anyhow = "1.0"
 indexmap = { version = "2.0", features = ["serde"] }
 clap = { version = "4.4", features = ["derive"] }
-cyclonedx-bom = "0.6"
+cyclonedx-bom = "0.8"
 spdx-rs = "0.5"
-spdx = "0.10"
-packageurl = "0.3"
-sha2 = "0.10"
+spdx = "0.13"
+packageurl = "0.6"
+sha2 = "0.11"
 hex = "0.4"
 
 [profile.release]

--- a/crates/sbom-model-cyclonedx/src/lib.rs
+++ b/crates/sbom-model-cyclonedx/src/lib.rs
@@ -212,7 +212,7 @@ impl CycloneDxReader {
                         }
                     }
                     cyclonedx_bom::models::tool::Tools::Object { components, .. } => {
-                        for component in components.0 {
+                        for component in components.into_iter().flat_map(|c| c.0) {
                             let mut s = component.name.to_string();
                             if let Some(v) = &component.version {
                                 s.push(' ');

--- a/crates/sbom-model-spdx/src/lib.rs
+++ b/crates/sbom-model-spdx/src/lib.rs
@@ -1096,7 +1096,9 @@ mod tests {
         assert!(find("both-noassertion").licenses.is_empty());
 
         // Valid concluded -> uses concluded, ignores declared
-        assert!(find("concluded-present").licenses.contains("GPL-3.0"));
+        // spdx 0.13 preserves the canonical SPDX id (GPL-3.0-only) rather than
+        // collapsing it to the deprecated short form (GPL-3.0) as 0.10 did.
+        assert!(find("concluded-present").licenses.contains("GPL-3.0-only"));
         assert!(!find("concluded-present").licenses.contains("MIT"));
 
         // No license fields at all -> empty

--- a/deny.toml
+++ b/deny.toml
@@ -5,6 +5,7 @@ ignore = []
 # We allow common OSS licenses
 allow = [
     "MIT",
+    "MIT-0",
     "Apache-2.0",
     "BSD-3-Clause",
     "BSD-2-Clause",


### PR DESCRIPTION
Carries Dependabot #67's 5-crate group bump plus the migrations:
- cyclonedx-bom 0.8: `Tools::Object.components` is now `Option<Components>` — flatten before iterating.
- spdx 0.13: preserves canonical SPDX ids (`GPL-3.0-only`) instead of collapsing to deprecated short forms (`GPL-3.0`). **Behavior change**: the tool now emits canonical, non-deprecated license ids. Updated the one test that still asserted the old short form (all others already expected canonical).

Rebased on main. Verified locally: workspace `cargo test --all-features` all pass, `clippy --all-targets --all-features -- -D warnings` clean. Supersedes #67.